### PR TITLE
adding set_label action

### DIFF
--- a/google-cloud-compute/info.json
+++ b/google-cloud-compute/info.json
@@ -487,6 +487,60 @@
                 "warning": {},
                 "unreachables": []
             }
-        }
+        },
+        {
+			"operation": "set_label",
+			"title": "Set Label",
+			"description": "set-user defined label on instance",
+			"enabled": true,
+			"category": "investigation",
+			"annotation": "set device label",
+			"parameters": [
+				{
+					"title": "Zone",
+					"type": "text",
+					"name": "zone",
+					"required": true,
+					"visible": true,
+					"editable": true,
+					"tooltip": "The name of the zone for this request."
+				},
+                {
+					"title": "instance_name",
+					"type": "text",
+					"name": "instance_name",
+					"required": true,
+					"visible": true,
+					"editable": true,
+					"tooltip": "The name of the instance for this request."
+				},
+                {
+					"title": "new_key",
+					"type": "text",
+					"name": "new_key",
+					"required": true,
+					"visible": true,
+					"editable": true,
+					"tooltip": "New Label Key"
+				},
+				{
+					"title": "new_value",
+					"type": "text",
+					"name": "new_value",
+					"required": true,
+					"visible": true,
+					"editable": true,
+					"tooltip": "New Label value"
+				}
+                ],
+			"output_schema": {
+				"kind": "",
+				"id": "",
+				"items": [],
+				"nextPageToken": "",
+				"selfLink": "",
+				"warning": {}
+			}
+		}
     ]
 }

--- a/google-cloud-compute/info.json
+++ b/google-cloud-compute/info.json
@@ -494,7 +494,7 @@
 			"description": "set-user defined label on instance",
 			"enabled": true,
 			"category": "investigation",
-			"annotation": "set device label",
+			"annotation": "set_device_label",
 			"parameters": [
 				{
 					"title": "Zone",


### PR DESCRIPTION
I have added an action to set a label on GCP instance.  This label can be used by FortiGate GCP SDN connector as part of a pre-existing policy framework.  The idea being that a CSPM or other service identifies a compromised host.  FortiSOAR triggers based on an event and then modifies the device label in GCP which allows the  matching FortiGate Policy to perform it's mitigating action. 